### PR TITLE
HAS-142: align the github-script pin with the other repos (v9.0.0)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Comment PR with SonarQube results
         if: github.event_name == 'pull_request' && steps.sonar.outcome == 'failure'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.issues.createComment({


### PR DESCRIPTION
One-line consistency fix found while auditing `uses:` versions across all workflows in the workspace.

`sonar.yml` pinned `actions/github-script` to `ed59741` (v8.0.0) — the pin added during HAS-126 —
while `cholewa-commons`, `cholewa-security`, `shelly-client` and `smart-home-sdk` are already on
`3a2844b` (v9.0.0). Both versions run on Node 24, so this is **not** part of the Node 20
deprecation (that one is HAS-140 for the Docker actions); it is purely alignment.

`amx-service/sonar.yml` uses the moving tag `@v8` for the same step and is deliberately left alone —
its workflows get modernised during its own Java 21 migration.

The step only fires when the Sonar quality gate fails on a PR, so a green run does not exercise it;
YAML parses and the sonar workflow runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)