### PR TITLE
HAS-138: enforce uniqueness of (point, gateway) in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ come back in the shared `Errors` JSON contract.
 - **Migrations:** Flyway (JDBC driver) from `src/main/resources/db/migration`.
 - **Schema:** table `eaton_devices` (`point`, `room`, `type`, `gateway` + audit timestamps).
   The original `device_configuration` table was superseded by it and dropped in `V6`.
+- **Constraints** (`V7`): `(point, gateway)` is unique — it is the natural key of an Eaton
+  device. Every gateway numbers its own devices, so the same `point` on a *different*
+  gateway is perfectly valid and stays allowed; only the exact pair cannot repeat. `point`
+  is additionally checked to be within `1..99`, the range an Eaton gateway addresses.
+  A violation of either surfaces as `400`, not `500` — see the API table.

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<mapstruct.version>1.6.3</mapstruct.version>
 
 		<!--  internal dependencies versions-->
-		<cholewa-commons.version>1.1.0</cholewa-commons.version>
+		<cholewa-commons.version>1.2.0</cholewa-commons.version>
 		<smart-home-sdk.version>1.0.0</smart-home-sdk.version>
 
 		<!--  plugins versions-->

--- a/src/main/java/cloud/cholewa/data/config/ExceptionHandlerConfig.java
+++ b/src/main/java/cloud/cholewa/data/config/ExceptionHandlerConfig.java
@@ -4,6 +4,7 @@ import cloud.cholewa.commons.error.GlobalErrorExceptionHandler;
 import cloud.cholewa.data.error.DeviceConfigurationNotFoundException;
 import cloud.cholewa.data.error.InvalidDeviceConfigurationException;
 import cloud.cholewa.data.error.processor.DeviceConfigurationNotFoundExceptionProcessor;
+import cloud.cholewa.data.error.processor.DuplicateConfigurationExceptionProcessor;
 import cloud.cholewa.data.error.processor.InvalidDeviceConfigurationExceptionProcessor;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.webflux.error.ErrorAttributes;
@@ -11,6 +12,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.codec.ServerCodecConfigurer;
 
 import java.util.Map;
@@ -39,7 +41,8 @@ public class ExceptionHandlerConfig {
                 Map.entry(
                     DeviceConfigurationNotFoundException.class,
                     new DeviceConfigurationNotFoundExceptionProcessor()
-                )
+                ),
+                Map.entry(DuplicateKeyException.class, new DuplicateConfigurationExceptionProcessor())
             )
         );
 

--- a/src/main/java/cloud/cholewa/data/error/processor/DuplicateConfigurationExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/data/error/processor/DuplicateConfigurationExceptionProcessor.java
@@ -10,18 +10,18 @@ import org.springframework.http.HttpStatus;
 import java.util.Collections;
 
 @Slf4j
-public class DeviceConfigurationNotFoundExceptionProcessor implements ExceptionProcessor {
+public class DuplicateConfigurationExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
         log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         return Errors.builder()
-            .httpStatus(HttpStatus.NOT_FOUND)
+            .httpStatus(HttpStatus.BAD_REQUEST)
             .errors(Collections.singleton(
                 ErrorMessage.builder()
-                    .message(CustomErrorDescription.NOT_FOUND_DEVICE_CONFIGURATION.getDescription())
-                    .details(throwable.getMessage())
+                    .message("Invalid device configuration")
+                    .details(CustomErrorDescription.CONFIGURATION_EXIST.getDescription())
                     .build()
             ))
             .build();

--- a/src/main/java/cloud/cholewa/data/error/processor/InvalidDeviceConfigurationExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/data/error/processor/InvalidDeviceConfigurationExceptionProcessor.java
@@ -3,14 +3,18 @@ package cloud.cholewa.data.error.processor;
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
 import cloud.cholewa.commons.error.processor.ExceptionProcessor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collections;
 
+@Slf4j
 public class InvalidDeviceConfigurationExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)
             .errors(Collections.singleton(

--- a/src/main/resources/db/migration/V7__unique_point_gateway.sql
+++ b/src/main/resources/db/migration/V7__unique_point_gateway.sql
@@ -1,0 +1,11 @@
+DELETE FROM eaton_devices a
+    USING eaton_devices b
+WHERE a.point = b.point
+  AND a.gateway = b.gateway
+  AND a.id > b.id;
+
+ALTER TABLE eaton_devices
+    ADD CONSTRAINT eaton_devices_point_gateway_uq UNIQUE (point, gateway);
+
+ALTER TABLE eaton_devices
+    ADD CONSTRAINT eaton_devices_point_range CHECK (point BETWEEN 1 AND 99);

--- a/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -86,5 +87,20 @@ class EatonDeviceConfigurationControllerTest {
             .uri("/device/configuration/eaton?point=1&gateway=blinds")
             .exchange()
             .expectStatus().isNotFound();
+    }
+
+    @Test
+    void should_return_bad_request_when_configuration_violates_unique_constraint() {
+        when(eatonDeviceConfigurationService.add(any()))
+            .thenReturn(Mono.error(new DuplicateKeyException("test")));
+
+        webTestClient.post()
+            .uri("/device/configuration/eaton")
+            .body(BodyInserters.fromValue(EATON_DEVICE_CONFIGURATION))
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Invalid device configuration")
+            .jsonPath("$.errors[0].details").isEqualTo("Configuration exist in database");
     }
 }


### PR DESCRIPTION
Found by the `service-review` during HAS-126. Unblocked by HAS-137 (`cholewa-commons` 1.2.0).

## Why this matters more for reads than for writes

`add()` checks `existsByPointAndGateway` and then saves — two steps, not atomic — and
`eaton_devices` had no unique index, so the invariant lived only in the code. The bigger risk
is on the **read** path: `findByPointAndGateway` returns a `Mono`, so a single duplicate row makes
every read of that device fail with `IncorrectResultSizeDataAccessException` — a 500 for
`amx-service` — until the table is cleaned by hand.

## Changes

- **`V7__unique_point_gateway.sql`** — de-duplicates first (keeping the oldest row per pair, which
  matches what the pre-check would have done), then adds `UNIQUE (point, gateway)`.
  The pair is the natural key: every Eaton gateway numbers its own devices `1..99`, so **the same
  `point` on a different gateway stays valid** — only the exact pair cannot repeat.
- The same migration adds `CHECK (point BETWEEN 1 AND 99)` — the range an Eaton gateway addresses,
  which the `NUMERIC(2)` column never enforced.
- **`cholewa-commons` 1.1.0 → 1.2.0** so a constraint violation renders as `400` instead of `500`.
- **`DuplicateConfigurationExceptionProcessor`** keeps the race path byte-identical to the
  pre-check response. `details` comes from the `CONFIGURATION_EXIST` constant, never from the
  driver message — that text names the table and the constraint.
- Log level/format aligned in the two existing processors (`warn` for 4xx, `Handled [{}]: {}`),
  matching the HAS-132 convention.

## Verification

- `mvn verify` on JDK 21: 10/10 tests, enforcer and `tidy:check` green.
- **The migration was run against a real PostgreSQL** by starting the service on the `local`
  profile — the `test` profile disables Flyway, so that is the only place `V7` executes before the
  cluster.
- Production table checked beforehand: 13 rows, all `point` values in 40–60, and
  `GROUP BY point, gateway HAVING count(*) > 1` returned nothing — the `DELETE` has nothing to
  remove and the `CHECK` cannot fail on existing data.

## Side effect worth knowing

A `point` outside `1..99` now violates the CHECK → SQLSTATE 23514 → `DataIntegrityViolationException`
→ **400 "Data integrity violation"** instead of the previous 500. This does not replace HAS-136
(the message is generic and validation belongs before the database), but the 500 described there
disappears with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)