### PR TITLE
HAS-135: return 400 for an unknown Eaton gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ schema is managed by **Flyway**, and the whole request path is non-blocking (Spr
 
 # API
 
-Base path `/home` (`spring.webflux.base-path`); external traffic reaches it through
-`api-gateway-service`.
+Base path `/home` (`spring.webflux.base-path`). The service is internal — it does not
+register with service discovery and `api-gateway-service` defines no route to it, so it is
+not reachable from outside the cluster. `amx-service` calls it directly over the cluster
+network (`internal.service.database` in its configuration).
 
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/home/device/configuration/eaton` | Register an Eaton device configuration (`EatonDeviceConfiguration`: point, room, type, gateway). Returns `201 Created`; a configuration already registered for that point + gateway returns `400 Bad Request`. |
-| `GET` | `/home/device/configuration/eaton?point=<n>&gateway=<name>` | Look up the configuration for a data point on a gateway. Returns `200 OK` with `EatonConfigurationResponse`; `404 Not Found` when no such configuration exists. |
+| `GET` | `/home/device/configuration/eaton?point=<n>&gateway=<name>` | Look up the configuration for a data point on a gateway. `gateway` is `blinds` or `lights`, matched case-insensitively (`amx-service` sends `BLINDS`). Returns `200 OK` with `EatonConfigurationResponse`; `404 Not Found` when no configuration exists for the pair; `400 Bad Request` when `gateway` is not one of the known values. |
 
 Errors are rendered through `cholewa-commons`' `GlobalErrorExceptionHandler`, so failures
 come back in the shared `Errors` JSON contract.

--- a/src/main/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationService.java
+++ b/src/main/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import static cloud.cholewa.data.error.CustomErrorDescription.CONFIGURATION_EXIST;
+import static cloud.cholewa.data.error.CustomErrorDescription.UNKNOWN_GATEWAY;
 
 @Slf4j
 @Service
@@ -31,7 +32,12 @@ public class EatonDeviceConfigurationService {
     }
 
     public Mono<EatonConfigurationResponse> get(final Integer dataPoint, final String gateway) {
-        return repository.findByPointAndGateway(dataPoint, EatonGatewayType.fromValue(gateway))
+        return Mono.fromCallable(() -> EatonGatewayType.fromValue(gateway))
+            .onErrorMap(
+                IllegalArgumentException.class,
+                e -> new InvalidDeviceConfigurationException(UNKNOWN_GATEWAY.getDescription() + ": " + gateway)
+            )
+            .flatMap(gatewayType -> repository.findByPointAndGateway(dataPoint, gatewayType))
             .doOnNext(eatonConfiguration ->
                 log.info(
                     "Found Eaton device configuration for dataPoint: {}, in room: {}",

--- a/src/main/java/cloud/cholewa/data/error/CustomErrorDescription.java
+++ b/src/main/java/cloud/cholewa/data/error/CustomErrorDescription.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum CustomErrorDescription implements ErrorId {
 
     CONFIGURATION_EXIST("Configuration exist in database"),
-    NOT_FOUND_DEVICE_CONFIGURATION("Device configuration not found");
+    NOT_FOUND_DEVICE_CONFIGURATION("Device configuration not found"),
+    UNKNOWN_GATEWAY("Unknown Eaton gateway");
 
     @Getter
     private final String description;

--- a/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
@@ -103,4 +103,18 @@ class EatonDeviceConfigurationControllerTest {
             .jsonPath("$.errors[0].message").isEqualTo("Invalid device configuration")
             .jsonPath("$.errors[0].details").isEqualTo("Configuration exist in database");
     }
+
+    @Test
+    void should_return_bad_request_when_unknown_gateway() {
+        when(eatonDeviceConfigurationService.get(anyInt(), anyString()))
+            .thenReturn(Mono.error(new InvalidDeviceConfigurationException("Unknown Eaton gateway")));
+
+        webTestClient.get()
+            .uri("/device/configuration/eaton?point=1&gateway=garden")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Invalid device configuration")
+            .jsonPath("$.errors[0].details").isEqualTo("Unknown Eaton gateway");
+    }
 }

--- a/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
@@ -107,7 +107,7 @@ class EatonDeviceConfigurationControllerTest {
     @Test
     void should_return_bad_request_when_unknown_gateway() {
         when(eatonDeviceConfigurationService.get(anyInt(), anyString()))
-            .thenReturn(Mono.error(new InvalidDeviceConfigurationException("Unknown Eaton gateway")));
+            .thenReturn(Mono.error(new InvalidDeviceConfigurationException("Unknown Eaton gateway: garden")));
 
         webTestClient.get()
             .uri("/device/configuration/eaton?point=1&gateway=garden")
@@ -115,6 +115,6 @@ class EatonDeviceConfigurationControllerTest {
             .expectStatus().isBadRequest()
             .expectBody()
             .jsonPath("$.errors[0].message").isEqualTo("Invalid device configuration")
-            .jsonPath("$.errors[0].details").isEqualTo("Unknown Eaton gateway");
+            .jsonPath("$.errors[0].details").isEqualTo("Unknown Eaton gateway: garden");
     }
 }

--- a/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import static cloud.cholewa.data.error.CustomErrorDescription.UNKNOWN_GATEWAY;
 import static cloud.cholewa.home.model.EatonGatewayType.BLINDS;
 import static cloud.cholewa.home.model.EatonGatewayType.LIGHTS;
 import static cloud.cholewa.home.model.RoomName.LIVING_ROOM;
@@ -98,7 +99,7 @@ class EatonDeviceConfigurationServiceTest {
     }
 
     @Test
-    void should_find_eaton_device_when_configuration_exists() {
+    void should_find_eaton_device_when_configuration_exists_for_lowercase_gateway() {
         when(repository.findByPointAndGateway(anyInt(), any()))
             .thenReturn(Mono.just(EatonDeviceConfigurationEntity.builder().point(1).room(LIVING_ROOM).build()));
         when(mapper.toResponse(any()))
@@ -111,5 +112,34 @@ class EatonDeviceConfigurationServiceTest {
 
         verify(repository).findByPointAndGateway(anyInt(), any());
         verify(mapper).toResponse(any());
+    }
+
+    @Test
+    void should_find_eaton_device_when_configuration_exists_for_uppercase_gateway() {
+        when(repository.findByPointAndGateway(anyInt(), any()))
+            .thenReturn(Mono.just(EatonDeviceConfigurationEntity.builder().point(1).room(LIVING_ROOM).build()));
+        when(mapper.toResponse(any()))
+            .thenReturn(EatonConfigurationResponse.builder().room(LIVING_ROOM).build());
+
+        sut.get(1, "BLINDS")
+            .as(StepVerifier::create)
+            .expectNextCount(1)
+            .verifyComplete();
+
+        verify(repository).findByPointAndGateway(anyInt(), any());
+        verify(mapper).toResponse(any());
+    }
+
+    @Test
+    void should_throw_exception_for_unknown_gateway() {
+
+        sut.get(1, "garden")
+            .as(StepVerifier::create)
+            .expectErrorSatisfies(throwable ->
+                Assertions.assertThat(throwable)
+                    .isInstanceOf(InvalidDeviceConfigurationException.class)
+                    .hasMessageContaining(UNKNOWN_GATEWAY.getDescription() + ": garden")
+            )
+            .verify();
     }
 }

--- a/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
@@ -12,6 +12,8 @@ import cloud.cholewa.home.model.SmartDeviceType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -98,30 +100,15 @@ class EatonDeviceConfigurationServiceTest {
         verifyNoMoreInteractions(repository);
     }
 
-    @Test
-    void should_find_eaton_device_when_configuration_exists_for_lowercase_gateway() {
+    @ParameterizedTest
+    @ValueSource(strings = {"blinds", "BLINDS"})
+    void should_find_eaton_device_when_configuration_exists(final String gateway) {
         when(repository.findByPointAndGateway(anyInt(), any()))
             .thenReturn(Mono.just(EatonDeviceConfigurationEntity.builder().point(1).room(LIVING_ROOM).build()));
         when(mapper.toResponse(any()))
             .thenReturn(EatonConfigurationResponse.builder().room(LIVING_ROOM).build());
 
-        sut.get(1, "blinds")
-            .as(StepVerifier::create)
-            .expectNextCount(1)
-            .verifyComplete();
-
-        verify(repository).findByPointAndGateway(anyInt(), any());
-        verify(mapper).toResponse(any());
-    }
-
-    @Test
-    void should_find_eaton_device_when_configuration_exists_for_uppercase_gateway() {
-        when(repository.findByPointAndGateway(anyInt(), any()))
-            .thenReturn(Mono.just(EatonDeviceConfigurationEntity.builder().point(1).room(LIVING_ROOM).build()));
-        when(mapper.toResponse(any()))
-            .thenReturn(EatonConfigurationResponse.builder().room(LIVING_ROOM).build());
-
-        sut.get(1, "BLINDS")
+        sut.get(1, gateway)
             .as(StepVerifier::create)
             .expectNextCount(1)
             .verifyComplete();
@@ -141,7 +128,6 @@ class EatonDeviceConfigurationServiceTest {
             )
             .verify();
 
-        verifyNoInteractions(repository);
-        verifyNoInteractions(mapper);
+        verifyNoInteractions(repository, mapper);
     }
 }

--- a/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/service/EatonDeviceConfigurationServiceTest.java
@@ -126,13 +126,12 @@ class EatonDeviceConfigurationServiceTest {
             .expectNextCount(1)
             .verifyComplete();
 
-        verify(repository).findByPointAndGateway(anyInt(), any());
+        verify(repository).findByPointAndGateway(anyInt(), eq(BLINDS));
         verify(mapper).toResponse(any());
     }
 
     @Test
     void should_throw_exception_for_unknown_gateway() {
-
         sut.get(1, "garden")
             .as(StepVerifier::create)
             .expectErrorSatisfies(throwable ->
@@ -141,5 +140,8 @@ class EatonDeviceConfigurationServiceTest {
                     .hasMessageContaining(UNKNOWN_GATEWAY.getDescription() + ": garden")
             )
             .verify();
+
+        verifyNoInteractions(repository);
+        verifyNoInteractions(mapper);
     }
 }


### PR DESCRIPTION
Closes [HAS-135](https://magikabdul.atlassian.net/browse/HAS-135) (epic HAS-134 — Eaton device configuration API hardening).

## Problem

`EatonGatewayType.fromValue` was evaluated eagerly as an argument to `repository.findByPointAndGateway`, so `GET /device/configuration/eaton?point=1&gateway=garden` threw `IllegalArgumentException` **synchronously** out of `EatonDeviceConfigurationService#get`:

- the controller never got to attach its `doOnSubscribe` log, so the query was not logged at all;
- no processor was registered for that exception type, so `cholewa-commons`' `DefaultExceptionProcessor` rendered **500** `"Unhandled error, update processor configuration"`;
- `amx-service`'s `DeviceDatabaseClient` consequently reported a server error for what is a bad request.

## Change

- the conversion moves inside the reactive chain (`Mono.fromCallable`) — it now runs at subscribe time and the failure travels as an error signal, so the `doOnSubscribe` log works again;
- `onErrorMap` turns it into `InvalidDeviceConfigurationException`, already wired to **400** by `InvalidDeviceConfigurationExceptionProcessor`;
- new `CustomErrorDescription.UNKNOWN_GATEWAY`, so the response details come from a constant rather than the enum's raw message.

Mapping the domain exception was preferred over registering `IllegalArgumentException` in `ExceptionHandlerConfig`: `cholewa-commons` selects processors by exception hierarchy since 1.1.0 (HAS-131), so such an entry would also catch `NumberFormatException` and every internal programming error, turning genuine 500s into 400s.

## Tests

- service: unknown gateway maps to `InvalidDeviceConfigurationException`; `"BLINDS"` (uppercase) still resolves — `amx-service` sends `gateway.name()`, so case-insensitivity of `fromValue` now has its own test next to the lowercase one;
- controller (`@WebFluxTest`): `?gateway=garden` returns 400 with the shared `Errors` body. The service is a `@MockitoBean` there, so this case covers the exception-to-status wiring; the real conversion is covered by the service test.

`mvn verify` green on JDK 21 — 13 tests, enforcer and `tidy:check` pass.

## Out of scope

The POST path has the same weakness on the request body (`@JsonCreator fromValue` → `DecodingException`) — that is HAS-136.