### PR TITLE
HAS-136: validate the Eaton device configuration request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ network (`internal.service.database` in its configuration).
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/home/device/configuration/eaton` | Register an Eaton device configuration (`EatonDeviceConfiguration`: point, room, type, gateway). Returns `201 Created`; a configuration already registered for that point + gateway returns `400 Bad Request`. |
+| `POST` | `/home/device/configuration/eaton` | Register an Eaton device configuration (`EatonDeviceConfiguration`: point, room, type, gateway — all four required, `point` in the range 1..99). Returns `201 Created`; an incomplete body or a `point` outside the range returns `400 Bad Request`, and so does a configuration already registered for that point + gateway. |
 | `GET` | `/home/device/configuration/eaton?point=<n>&gateway=<name>` | Look up the configuration for a data point on a gateway. `gateway` is `blinds` or `lights`, matched case-insensitively (`amx-service` sends `BLINDS`). Returns `200 OK` with `EatonConfigurationResponse`; `404 Not Found` when no configuration exists for the pair; `400 Bad Request` when `gateway` is not one of the known values. |
 
 Errors are rendered through `cholewa-commons`' `GlobalErrorExceptionHandler`, so failures

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
 		<!--  internal dependencies versions-->
 		<cholewa-commons.version>1.2.0</cholewa-commons.version>
-		<smart-home-sdk.version>1.0.0</smart-home-sdk.version>
+		<smart-home-sdk.version>1.1.0</smart-home-sdk.version>
 
 		<!--  plugins versions-->
 		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>

--- a/src/main/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationController.java
+++ b/src/main/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationController.java
@@ -3,6 +3,7 @@ package cloud.cholewa.data.device.eaton.api;
 import cloud.cholewa.data.device.eaton.service.EatonDeviceConfigurationService;
 import cloud.cholewa.home.model.EatonConfigurationResponse;
 import cloud.cholewa.home.model.EatonDeviceConfiguration;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,7 +26,7 @@ public class EatonDeviceConfigurationController {
 
     @PostMapping
     Mono<ResponseEntity<Void>> addEatonDeviceConfiguration(
-        @RequestBody final EatonDeviceConfiguration eatonDeviceConfiguration
+        @Valid @RequestBody final EatonDeviceConfiguration eatonDeviceConfiguration
     ) {
         return eatonDeviceConfigurationService.add(eatonDeviceConfiguration)
             .doOnSubscribe(subscription ->

--- a/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
@@ -10,6 +10,9 @@ import cloud.cholewa.home.model.EatonGatewayType;
 import cloud.cholewa.home.model.RoomName;
 import cloud.cholewa.home.model.SmartDeviceType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
 import org.springframework.context.annotation.Import;
@@ -19,6 +22,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 
+import java.util.stream.Stream;
+
+import static cloud.cholewa.home.model.EatonGatewayType.LIGHTS;
+import static cloud.cholewa.home.model.RoomName.BEDROOM;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -116,5 +123,53 @@ class EatonDeviceConfigurationControllerTest {
             .expectBody()
             .jsonPath("$.errors[0].message").isEqualTo("Invalid device configuration")
             .jsonPath("$.errors[0].details").isEqualTo("Unknown Eaton gateway: garden");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideInvalidEatonDeviceConfiguration")
+    void should_return_bad_request_when_invalid_configuration(
+        final String name,
+        final EatonDeviceConfiguration invalidConfiguration
+    ) {
+        webTestClient.post()
+            .uri("/device/configuration/eaton")
+            .body(BodyInserters.fromValue(invalidConfiguration))
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Missing or invalid parameter");
+    }
+
+    private static Stream<Arguments> provideInvalidEatonDeviceConfiguration() {
+        return Stream.of(
+            Arguments.of(
+                "no body",
+                EatonDeviceConfiguration.builder().build()
+            ),
+            Arguments.of(
+                "no point",
+                EatonDeviceConfiguration.builder().type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+            ),
+            Arguments.of(
+                "no gateway",
+                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).room(BEDROOM).build()
+            ),
+            Arguments.of(
+                "no type",
+                EatonDeviceConfiguration.builder().point(1).gateway(LIGHTS).room(BEDROOM).build()
+            ),
+            Arguments.of(
+                "no room",
+                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).gateway(LIGHTS).build()
+            ),
+            Arguments.of(
+                "point less than 1",
+                EatonDeviceConfiguration.builder().point(0).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+            ),
+            Arguments.of(
+                "point greater than 100",
+                EatonDeviceConfiguration.builder().point(100).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+            )
+        );
     }
 }

--- a/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
+++ b/src/test/java/cloud/cholewa/data/device/eaton/api/EatonDeviceConfigurationControllerTest.java
@@ -22,13 +22,16 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static cloud.cholewa.home.model.EatonGatewayType.LIGHTS;
 import static cloud.cholewa.home.model.RoomName.BEDROOM;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @Import(ExceptionHandlerConfig.class)
@@ -125,11 +128,45 @@ class EatonDeviceConfigurationControllerTest {
             .jsonPath("$.errors[0].details").isEqualTo("Unknown Eaton gateway: garden");
     }
 
+    @Test
+    void should_return_bad_request_when_body_missing() {
+        webTestClient.post()
+            .uri("/device/configuration/eaton")
+            .body(BodyInserters.empty())
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Missing request body");
+
+        verifyNoInteractions(eatonDeviceConfigurationService);
+    }
+
+    @Test
+    void should_return_bad_request_when_all_fields_missing() {
+        webTestClient.post()
+            .uri("/device/configuration/eaton")
+            .body(BodyInserters.fromValue(EatonDeviceConfiguration.builder().build()))
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors.length()").isEqualTo(4)
+            .jsonPath("$.errors[*].details")
+            .value((List<String> details) -> assertThat(details).containsExactlyInAnyOrder(
+                "point",
+                "type",
+                "gateway",
+                "room"
+            ));
+
+        verifyNoInteractions(eatonDeviceConfigurationService);
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("provideInvalidEatonDeviceConfiguration")
     void should_return_bad_request_when_invalid_configuration(
         final String name,
-        final EatonDeviceConfiguration invalidConfiguration
+        final EatonDeviceConfiguration invalidConfiguration,
+        final String details
     ) {
         webTestClient.post()
             .uri("/device/configuration/eaton")
@@ -137,38 +174,43 @@ class EatonDeviceConfigurationControllerTest {
             .exchange()
             .expectStatus().isBadRequest()
             .expectBody()
-            .jsonPath("$.errors[0].message").isEqualTo("Missing or invalid parameter");
+            .jsonPath("$.errors[0].message").isEqualTo("Missing or invalid parameter")
+            .jsonPath("$.errors[0].details").isEqualTo(details);
+
+        verifyNoInteractions(eatonDeviceConfigurationService);
     }
 
     private static Stream<Arguments> provideInvalidEatonDeviceConfiguration() {
         return Stream.of(
             Arguments.of(
-                "no body",
-                EatonDeviceConfiguration.builder().build()
-            ),
-            Arguments.of(
                 "no point",
-                EatonDeviceConfiguration.builder().type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+                EatonDeviceConfiguration.builder().type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build(),
+                "point"
             ),
             Arguments.of(
                 "no gateway",
-                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).room(BEDROOM).build()
+                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).room(BEDROOM).build(),
+                "gateway"
             ),
             Arguments.of(
                 "no type",
-                EatonDeviceConfiguration.builder().point(1).gateway(LIGHTS).room(BEDROOM).build()
+                EatonDeviceConfiguration.builder().point(1).gateway(LIGHTS).room(BEDROOM).build(),
+                "type"
             ),
             Arguments.of(
                 "no room",
-                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).gateway(LIGHTS).build()
+                EatonDeviceConfiguration.builder().point(1).type(SmartDeviceType.BLINDS).gateway(LIGHTS).build(),
+                "room"
             ),
             Arguments.of(
                 "point less than 1",
-                EatonDeviceConfiguration.builder().point(0).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+                EatonDeviceConfiguration.builder().point(0).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build(),
+                "point"
             ),
             Arguments.of(
-                "point greater than 100",
-                EatonDeviceConfiguration.builder().point(100).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build()
+                "point greater than 99",
+                EatonDeviceConfiguration.builder().point(100).type(SmartDeviceType.BLINDS).gateway(LIGHTS).room(BEDROOM).build(),
+                "point"
             )
         );
     }


### PR DESCRIPTION
## What

- Bumps `smart-home-sdk` to **1.1.0**, in which `EatonDeviceConfiguration` declares `point`,
  `type`, `gateway` and `room` as required (the generated model now carries `@NotNull`).
- Adds `@Valid` on the `@RequestBody` of `POST /device/configuration/eaton`.
- Adds a parameterized `@WebFluxTest` covering each missing field and `point` outside 1..99.

## Why

The endpoint accepted the body without validation, so nulls reached `eaton_devices`, whose
`point`, `room`, `type` and `gateway` columns are `NOT NULL`. The insert failed with
`DataIntegrityViolationException` and the caller got a **500**. Now the request is rejected
with a **400** before it reaches the service.

Fixed at the contract level (smart-home-sdk PR #11) rather than with hand-rolled null checks,
so the OpenAPI spec stops declaring mandatory fields optional. `@Valid` also activates the
existing `@Min(1)`/`@Max(99)` on `point`, which was inert until now — hence no range check in
the service either.

## Notes for review

- `EatonDeviceConfigurationService` is deliberately untouched: invalid payloads never reach it.
- The 400 body comes from `WebExchangeBindExceptionProcessor` in `cholewa-commons`
  (`message: "Missing or invalid parameter"`, one entry per violated field). This differs from
  the `"Invalid device configuration"` shape used by HAS-135 / HAS-138 — accepted, since the
  format comes from the shared library rather than from this service.
- No REST contract change for `amx-service`, which only calls `GET` on this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
