### PR TITLE
HAS-139: fix the Flyway URL default and clean up dead configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,15 @@ schema is managed by **Flyway**, and the whole request path is non-blocking (Spr
 - Build: `mvn verify` (JDK 21).
 - Ports: local profile `6005` (management `8005`); in the deployed `home` profile the
   service listens on `6200` like every service in the cluster.
-- Requires a reachable PostgreSQL instance. The R2DBC connection properties
-  (`database-host`, `database-port`, `database-name`, `database-user`, `database-password`)
-  have placeholder defaults, so the context starts without them and fails on the first
-  query instead.
-- `flyway-url` has no usable default — the placeholder is not a JDBC URL, so Flyway
-  refuses to parse it and the application does not start. Pass a real one, e.g.
-  `--flyway-url=jdbc:postgresql://localhost:5432/<database>`.
+- Requires a reachable PostgreSQL instance. The connection properties (`database-host`,
+  `database-port`, `database-name`, `database-user`, `database-password`) are bound to the
+  service's own `database.*` prefix through `DatabaseProperties` and have placeholder
+  defaults, so the context starts without them and fails on the first query instead.
+- Flyway derives its JDBC URL from those same properties
+  (`jdbc:postgresql://<database-host>:<database-port>/<database-name>`, defaulting to
+  `localhost:5432`), so a local run needs no extra flag. Override with `--flyway-url=...`
+  only when migrations have to target a different URL than the connection properties
+  describe; the deployed environment supplies it explicitly.
 - Flyway is enabled in `home`/`local` and disabled in the `test` profile.
 
 # API

--- a/src/main/java/cloud/cholewa/data/DatabaseServiceApplication.java
+++ b/src/main/java/cloud/cholewa/data/DatabaseServiceApplication.java
@@ -2,12 +2,8 @@ package cloud.cholewa.data;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableConfigurationProperties()
-@EnableScheduling
 public class DatabaseServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/cloud/cholewa/data/config/DatabaseProperties.java
+++ b/src/main/java/cloud/cholewa/data/config/DatabaseProperties.java
@@ -1,0 +1,7 @@
+package cloud.cholewa.data.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("database")
+public record DatabaseProperties(String host, Integer port, String name, String username, String password) {
+}

--- a/src/main/java/cloud/cholewa/data/config/DbConfig.java
+++ b/src/main/java/cloud/cholewa/data/config/DbConfig.java
@@ -4,63 +4,31 @@ import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.r2dbc.core.DefaultReactiveDataAccessStrategy;
-import org.springframework.data.r2dbc.core.R2dbcEntityOperations;
-import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
-import org.springframework.data.r2dbc.dialect.PostgresDialect;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
-import org.springframework.r2dbc.connection.init.ConnectionFactoryInitializer;
-import org.springframework.r2dbc.core.DatabaseClient;
 
 @Configuration
 @EnableR2dbcRepositories
+@RequiredArgsConstructor
+@EnableConfigurationProperties(DatabaseProperties.class)
 public class DbConfig {
 
-    @Value("${spring.datasource.username}")
-    private String username;
-
-    @Value("${spring.datasource.password}")
-    private String password;
-
-    @Value("${spring.datasource.host}")
-    private String host;
-
-    @Value("${spring.datasource.port}")
-    private Integer port;
-
-    @Value("${spring.datasource.database}")
-    private String database;
+    private final DatabaseProperties databaseProperties;
 
     @Bean
     ConnectionFactory connectionFactory() {
         return ConnectionFactories.get(ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
-            .option(ConnectionFactoryOptions.HOST, host)
-            .option(ConnectionFactoryOptions.PORT, port)
-            .option(ConnectionFactoryOptions.DATABASE, database)
-            .option(ConnectionFactoryOptions.USER, username)
-            .option(ConnectionFactoryOptions.PASSWORD, password)
+            .option(ConnectionFactoryOptions.HOST, databaseProperties.host())
+            .option(ConnectionFactoryOptions.PORT, databaseProperties.port())
+            .option(ConnectionFactoryOptions.DATABASE, databaseProperties.name())
+            .option(ConnectionFactoryOptions.USER, databaseProperties.username())
+            .option(ConnectionFactoryOptions.PASSWORD, databaseProperties.password())
             .option(Option.valueOf("sslMode"), "REQUIRE")
             .build()
         );
-    }
-
-    @Bean
-    R2dbcEntityOperations entityTemplate(ConnectionFactory connectionFactory) {
-        DefaultReactiveDataAccessStrategy strategy = new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE);
-
-        DatabaseClient databaseClient = DatabaseClient.builder().connectionFactory(connectionFactory).build();
-
-        return new R2dbcEntityTemplate(databaseClient, strategy);
-    }
-
-    @Bean
-    ConnectionFactoryInitializer initializer(ConnectionFactory connectionFactory) {
-        ConnectionFactoryInitializer initializer = new ConnectionFactoryInitializer();
-        initializer.setConnectionFactory(connectionFactory);
-        return initializer;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,19 +6,18 @@ spring:
     active: home
   webflux:
     base-path: "/home"
-  datasource:
-    host: ${database-host:localhost}
-    port: ${database-port:1433}
-    database: ${database-name:dummyName}
-    username: ${database-user:dummyUser}
-    password: ${database-password:dummyPassword}
   flyway:
-    url: ${flyway-url:localhost}
+    url: ${flyway-url:jdbc:postgresql://${database.host}:${database.port}/${database.name}}
     user: ${database-user:dummyUser}
     password: ${database-password:dummyPassword}
     enabled: on
-  jpa:
-    show-sql: true
+
+database:
+  host: ${database-host:localhost}
+  port: ${database-port:5432}
+  name: ${database-name:dummyName}
+  username: ${database-user:dummyUser}
+  password: ${database-password:dummyPassword}
 
 server:
   port: 6200


### PR DESCRIPTION
## What

- `spring.flyway.url` no longer defaults to a bare `localhost`; it is derived from the
  connection properties (`jdbc:postgresql://${database.host}:${database.port}/${database.name}`)
  and can still be overridden with `flyway-url`.
- Connection keys move out of Spring's `spring.datasource.*` namespace into the service's own
  `database.*` prefix, bound through a `DatabaseProperties` record instead of five `@Value` fields.
- Removes dead configuration: `spring.jpa.show-sql` (no JPA on the classpath), `@EnableScheduling`
  (no `@Scheduled` anywhere), the empty `@EnableConfigurationProperties()`, the hand-rolled
  `R2dbcEntityTemplate` and a `ConnectionFactoryInitializer` with no populator.
- README "Run locally" updated to match.

## Why

The old default was not a JDBC URL, so Flyway refused to parse it and the service could not
start on the `local` profile without passing `flyway-url` by hand — the `test` profile hid this
because Flyway is disabled there. Deriving the URL from the same properties the R2DBC connection
uses also makes it impossible for migrations and queries to point at different databases, which
is what the old split invited (the datasource default was even port 1433, a SQL Server port).

Dropping the hand-rolled `R2dbcEntityTemplate` is the durable fix for HAS-126: Boot autoconfigures
the template and resolves the dialect from the `ConnectionFactory` via `DialectResolver`, so the
SqlServer/Postgres mismatch fixed there cannot be reintroduced by a stale hardcoded dialect.

## Notes for review

- The k8s manifest needs no change: it injects `database-host`, `database-port`, `database-name`,
  `database-user`, `database-password` and `flyway-url` by name, and only the Spring keys that
  consume those placeholders moved.
- `sslMode: REQUIRE` is preserved on the connection factory.
- The context test covers the removed template bean: the R2DBC repository cannot be created
  without an `R2dbcEntityOperations` and a resolved dialect, so a green `contextLoads` proves the
  autoconfigured one took over.
- `mvn verify` green locally — 21 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
