### PR TITLE
HAS-140: bump Docker release actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,14 +51,14 @@ jobs:
         run: mvn -B package -DskipTests --file pom.xml
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 #v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: magikabdul/database-service
           tags: |
@@ -66,7 +66,7 @@ jobs:
             type=raw,value=${{ steps.version.outputs.GIT_TAG }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 #v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true


### PR DESCRIPTION
GitHub deprecated the Node 20 actions runtime. The `docker/*` actions pinned in
`release.yml` targeted Node 20 and were force-run on Node 24, which GitHub reported
as an annotation on every release run (first seen on the `database-service` 0.2.0
release, HAS-126). They stop working once the forced fallback is removed.

| Action | Before | After |
|---|---|---|
| `docker/login-action` | v3 (`5e57cd1`) | **v4.5.2** (`371161b`) |
| `docker/metadata-action` | v5 (`c299e40`) | **v6.2.0** (`dc80280`) |
| `docker/build-push-action` | v5 (`ca052bb`) | **v7.3.0** (`53b7df9`) |

- All three pinned to the tag's commit SHA with a trailing version comment (org rule —
  never a moving tag); every SHA verified against the upstream tag.
- All three new versions declare `using: node24`.
- Inputs used here (`username`/`password`, `images`/`tags`, `context`/`push`/`tags`/`labels`)
  are unchanged across these majors — checked in each action's `action.yml` at the pinned SHA.
- `login-action` is v4.5.2 rather than the v4.5.1 named in the ticket: v4.5.2 was released
  since and only improves Docker Hub OIDC error reporting.

`release.yml` only runs on a created GitHub release, so this cannot be exercised by a PR
build. Verification per the ticket: a patch release of `ai-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)