### PR TITLE
HAS-141: replace maven-settings-xml-action and fix Maven auth in release.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,22 +17,25 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
-        with:
-          servers: >
-            [
-              {
-                "id": "github-prv",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              },
-              {
-                "id": "github-org-smart-home",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              }
-            ]
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
 
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
@@ -43,6 +46,9 @@ jobs:
           overwrite-settings: false
 
       - name: Build with Maven
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
         run: mvn -B package --file pom.xml
 
       - name: Discord notification -> success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,30 +24,44 @@ jobs:
             echo "GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 'latest')" >> $GITHUB_OUTPUT
           fi
 
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-          server-id: github-prv
-          server-username: x-access-token
-          server-password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Maven settings for organization
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          server-id: github-org-smart-home
-          server-username: x-access-token
-          server-password: ${{ secrets.GITHUB_TOKEN }}
           overwrite-settings: false
 
       - name: Set project version
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
         run: mvn versions:set -DnewVersion=${{ steps.version.outputs.GIT_TAG }}
 
       - name: Build with Maven
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
         run: mvn -B package -DskipTests --file pom.xml
 
       - name: Log in to Docker Hub

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,22 +14,25 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
-        with:
-          servers: >
-            [
-              {
-                "id": "github-prv",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              },
-              {
-                "id": "github-org-smart-home",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              }
-            ]
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
 
       - name: Set up JDK 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
@@ -47,10 +50,15 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Build and test with JaCoCo
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
         run: mvn clean org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent test org.jacoco:jacoco-maven-plugin:0.8.12:report
 
       - name: Build and analyze
         env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests
 


### PR DESCRIPTION
`whelk-io/maven-settings-xml-action` runs on the deprecated **Node 20** runtime and has had
no release since February 2024 — unlike the Docker actions in HAS-140, it cannot be fixed by
a version bump. It is replaced by a plain `run:` step that writes `~/.m2/settings.xml`
with both GitHub Packages servers.

### `release.yml` never actually authenticated

Three independent defects, all fixed here:

1. `setup-java`'s `server-username`/`server-password` take **environment variable names**;
   the workflow passed the literal `x-access-token` and the interpolated secret value, so
   `settings.xml` ended up with `${env.x-access-token}` — a placeholder Maven cannot resolve.
2. The second step, *Set up Maven settings for organization*, was a **no-op**. With
   `overwrite-settings: false` the action skips generation entirely when the file exists
   ([`src/auth.ts`](https://github.com/actions/setup-java/blob/v5.6.0/src/auth.ts) — it does
   not merge), so `github-org-smart-home` never reached `settings.xml` at all.
3. `GITHUB_TOKEN` cannot read packages from the `magikabdul` account regardless.

Release builds only ever worked because the shared libraries came from the `~/.m2` cache
that `CI.yml` had populated. On a cache miss the release could not resolve
`cholewa-commons` or `smart-home-sdk`.

### The mechanism now used everywhere

The settings step writes both servers with `${env.GH_PRV_USERNAME}` / `${env.GH_PRV_PASSWORD}`
placeholders, every Maven step exports those secrets via `env:`, and `setup-java` keeps
`overwrite-settings: false` so it does not clobber the file. No third-party action, one less
thing to pin.

### Verification (on `ai-service`, cold Maven cache)

| Signal | Result |
|---|---|
| `Cache restored successfully` | 0 — genuinely cold |
| Downloads from `maven.pkg.github.com` | **1014** |
| Shared library | `github-prv: .../cloud/cholewa/cholewa-commons/1.1.0/cholewa-commons-1.1.0.jar` + `.pom` |
| 401 / Unauthorized | 0 |

The mechanism was also proven locally: `mvn help:effective-settings` resolves
`${env.…}` in both `<server>` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
